### PR TITLE
URL output containing two slashes leading to 404

### DIFF
--- a/bridges/DiscogsBridge.php
+++ b/bridges/DiscogsBridge.php
@@ -61,7 +61,7 @@ class DiscogsBridge extends BridgeAbstract {
 				$item['title'] = $release['title'];
 				$item['id'] = $release['id'];
 				$resId = array_key_exists('main_release', $release) ? $release['main_release'] : $release['id'];
-				$item['uri'] = self::URI . $this->getInput('artistid') . '/release/' . $resId;
+				$item['uri'] = self::URI . $this->getInput('artistid') . 'release/' . $resId;
 
 				if(isset($release['year'])) {
 					$item['timestamp'] = DateTime::createFromFormat('Y', $release['year'])->getTimestamp();
@@ -96,7 +96,7 @@ class DiscogsBridge extends BridgeAbstract {
 				$item['title'] = $infos['title'];
 				$item['author'] = $infos['artists'][0]['name'];
 				$item['id'] = $infos['artists'][0]['id'];
-				$item['uri'] = self::URI . $infos['artists'][0]['id'] . '/release/' . $infos['id'];
+				$item['uri'] = self::URI . $infos['artists'][0]['id'] . 'release/' . $infos['id'];
 				$item['timestamp'] = strtotime($element['date_added']);
 				$item['content'] = $item['author'] . ' - ' . $item['title'];
 				$this->items[] = $item;


### PR DESCRIPTION
Currently, the bridge generates a URL like `https://www.discogs.com//release/14314167` (notice the two slashes).

`self::URI` already contains a trailing `/`

This PR fixes that.

Cheers
Thomas